### PR TITLE
Integrate landscapes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+landscapes==0.0.10
 tsplib95>=0.3.2, <1.0.0
 matplotlib<3.2.0
 networkx==2.1

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     author='Leo Hanisch',
     license='BSD 3-Clause License',
     install_requires=[
+        'landscapes==0.0.10',
         'tsplib95>=0.3.2, <1.0.0',
         'matplotlib<3.2.0',  # Otherwise networkx throws an exception
         'networkx==2.1',  # Required by tsplib95 0.3.2

--- a/swarmlib/abc/main.py
+++ b/swarmlib/abc/main.py
@@ -36,7 +36,7 @@ def configure_parser(sub_parsers):
         type=str,
         default='michalewicz',
         help='Choose the function that is used for searching the minimum.',
-        choices=['michalewicz', 'ackley'])
+        choices=[*FUNCTIONS])
     parser.add_argument(
         '-u',
         '--upper-boundary',

--- a/swarmlib/abc/main.py
+++ b/swarmlib/abc/main.py
@@ -35,8 +35,12 @@ def configure_parser(sub_parsers):
         '--function',
         type=str,
         default='michalewicz',
-        help='Choose the function that is used for searching the minimum.',
-        choices=[*FUNCTIONS])
+        help='''Choose the function that is used for searching the minimum.
+        Choices are any of the 2D or nD single objective functions available
+        in the 'landscapes' package (https://git.io/JTSFv). Example arguments:
+        'michalewicz', 'ackley', 'rastrigin'.''',
+        choices=[*FUNCTIONS],
+        metavar='')
     parser.add_argument(
         '-u',
         '--upper-boundary',

--- a/swarmlib/cuckoosearch/main.py
+++ b/swarmlib/cuckoosearch/main.py
@@ -36,7 +36,7 @@ def configure_parser(sub_parsers):
         type=str,
         default='michalewicz',
         help='Choose the function that is used for searching the minimum.',
-        choices=['michalewicz', 'ackley'])
+        choices=[*FUNCTIONS])
     parser.add_argument(
         '-u',
         '--upper-boundary',

--- a/swarmlib/cuckoosearch/main.py
+++ b/swarmlib/cuckoosearch/main.py
@@ -35,8 +35,12 @@ def configure_parser(sub_parsers):
         '--function',
         type=str,
         default='michalewicz',
-        help='Choose the function that is used for searching the minimum.',
-        choices=[*FUNCTIONS])
+        help='''Choose the function that is used for searching the minimum.
+        Choices are any of the 2D or nD single objective functions available
+        in the 'landscapes' package (https://git.io/JTSFv). Example arguments:
+        'michalewicz', 'ackley', 'rastrigin'.''',
+        choices=[*FUNCTIONS],
+        metavar='')
     parser.add_argument(
         '-u',
         '--upper-boundary',

--- a/swarmlib/fireflyalgorithm/main.py
+++ b/swarmlib/fireflyalgorithm/main.py
@@ -34,8 +34,12 @@ def configure_parser(sub_parsers):
         '--function',
         type=str,
         default='michalewicz',
-        help='Choose the function that is used for searching the minimum.',
-        choices=[*FUNCTIONS])
+        help='''Choose the function that is used for searching the minimum.
+        Choices are any of the 2D or nD single objective functions available
+        in the 'landscapes' package (https://git.io/JTSFv). Example arguments:
+        'michalewicz', 'ackley', 'rastrigin'.''',
+        choices=[*FUNCTIONS],
+        metavar='')
     parser.add_argument(
         '-u',
         '--upper-boundary',

--- a/swarmlib/fireflyalgorithm/main.py
+++ b/swarmlib/fireflyalgorithm/main.py
@@ -35,7 +35,7 @@ def configure_parser(sub_parsers):
         type=str,
         default='michalewicz',
         help='Choose the function that is used for searching the minimum.',
-        choices=['michalewicz', 'ackley'])
+        choices=[*FUNCTIONS])
     parser.add_argument(
         '-u',
         '--upper-boundary',

--- a/swarmlib/gwo/main.py
+++ b/swarmlib/gwo/main.py
@@ -34,8 +34,12 @@ def configure_parser(sub_parsers):
         '--function',
         type=str,
         default='michalewicz',
-        help='Choose the function that is used for searching the minimum.',
-        choices=[*FUNCTIONS])
+        help='''Choose the function that is used for searching the minimum.
+        Choices are any of the 2D or nD single objective functions available
+        in the 'landscapes' package (https://git.io/JTSFv). Example arguments:
+        'michalewicz', 'ackley', 'rastrigin'.''',
+        choices=[*FUNCTIONS],
+        metavar='')
     parser.add_argument(
         '-u',
         '--upper-boundary',

--- a/swarmlib/gwo/main.py
+++ b/swarmlib/gwo/main.py
@@ -35,7 +35,7 @@ def configure_parser(sub_parsers):
         type=str,
         default='michalewicz',
         help='Choose the function that is used for searching the minimum.',
-        choices=['michalewicz', 'ackley'])
+        choices=[*FUNCTIONS])
     parser.add_argument(
         '-u',
         '--upper-boundary',

--- a/swarmlib/pso/main.py
+++ b/swarmlib/pso/main.py
@@ -36,7 +36,7 @@ def configure_parser(sub_parsers):
         type=str,
         default='michalewicz',
         help='Choose the function that is used for searching the minimum.',
-        choices=['michalewicz', 'ackley'])
+        choices=[*FUNCTIONS])
     parser.add_argument(
         '-u',
         '--upper-boundary',

--- a/swarmlib/pso/main.py
+++ b/swarmlib/pso/main.py
@@ -35,8 +35,12 @@ def configure_parser(sub_parsers):
         '--function',
         type=str,
         default='michalewicz',
-        help='Choose the function that is used for searching the minimum.',
-        choices=[*FUNCTIONS])
+        help='''Choose the function that is used for searching the minimum.
+        Choices are any of the 2D or nD single objective functions available
+        in the 'landscapes' package (https://git.io/JTSFv). Example arguments:
+        'michalewicz', 'ackley', 'rastrigin'.''',
+        choices=[*FUNCTIONS],
+        metavar='')
     parser.add_argument(
         '-u',
         '--upper-boundary',

--- a/swarmlib/util/functions.py
+++ b/swarmlib/util/functions.py
@@ -5,8 +5,9 @@
 
 #pylint: disable=invalid-name
 
-from functools import reduce
 import inspect
+from functools import reduce
+
 import landscapes.single_objective
 import numpy as np
 

--- a/swarmlib/util/functions.py
+++ b/swarmlib/util/functions.py
@@ -44,6 +44,7 @@ FUNCTIONS = {
     for (name, func) in inspect.getmembers(
         landscapes.single_objective, inspect.isfunction
     )
+    if name not in ['colville', 'wolfe'] # Don't include 3D and 4D functions
 }
 # Replace / add functions that are defined in this file
 FUNCTIONS.update({'michalewicz': michalewicz, 'ackley': ackley})

--- a/swarmlib/util/functions.py
+++ b/swarmlib/util/functions.py
@@ -6,6 +6,8 @@
 #pylint: disable=invalid-name
 
 from functools import reduce
+import inspect
+import landscapes.single_objective
 import numpy as np
 
 
@@ -28,7 +30,12 @@ def ackley(x, a=20, b=0.2, c=2*np.pi):
     return -a*np.exp(-b*np.sqrt(s1 / n)) - np.exp(s2 / n) + a + np.exp(1)
 
 
+# Add all functions from landscapes.single_objective
 FUNCTIONS = {
-    'michalewicz': michalewicz,
-    'ackley': ackley
+    name: func
+    for (name, func) in inspect.getmembers(
+        landscapes.single_objective, inspect.isfunction
+    )
 }
+# Replace / add functions that are defined in this file
+FUNCTIONS.update({'michalewicz': michalewicz, 'ackley': ackley})

--- a/swarmlib/util/functions.py
+++ b/swarmlib/util/functions.py
@@ -6,29 +6,9 @@
 #pylint: disable=invalid-name
 
 import inspect
-from functools import reduce
 
 import landscapes.single_objective
 import numpy as np
-
-
-def michalewicz(x):
-    m = 10
-
-    def func(x):
-        return np.sin(x) * np.power(np.sin((0 + 1) * np.power(x, 2) / np.pi), 2 * m)
-
-    result = reduce(lambda acc, x: acc + func(x), x, 0.0)
-    return -result
-
-
-def ackley(x, a=20, b=0.2, c=2*np.pi):
-
-    x = np.asarray_chkfinite(x)  # ValueError if any NaN or Inf
-    n = len(x)
-    s1 = np.sum(x**2, axis=0)
-    s2 = np.sum(np.cos(c * x), axis=0)
-    return -a*np.exp(-b*np.sqrt(s1 / n)) - np.exp(s2 / n) + a + np.exp(1)
 
 
 # Wrapper for landscapes.single_objective functions for inputs > 1d
@@ -46,5 +26,3 @@ FUNCTIONS = {
     )
     if name not in ['colville', 'wolfe'] # Don't include 3D and 4D functions
 }
-# Replace / add functions that are defined in this file
-FUNCTIONS.update({'michalewicz': michalewicz, 'ackley': ackley})

--- a/swarmlib/util/functions.py
+++ b/swarmlib/util/functions.py
@@ -30,9 +30,16 @@ def ackley(x, a=20, b=0.2, c=2*np.pi):
     return -a*np.exp(-b*np.sqrt(s1 / n)) - np.exp(s2 / n) + a + np.exp(1)
 
 
+# Wrapper for landscapes.single_objective functions for inputs > 1d
+def wrap_landscapes_func(landscapes_func):
+    def wrapper(x):
+        return np.apply_along_axis(func1d=landscapes_func, axis=0, arr=x)
+    return wrapper
+
+
 # Add all functions from landscapes.single_objective
 FUNCTIONS = {
-    name: func
+    name: wrap_landscapes_func(func)
     for (name, func) in inspect.getmembers(
         landscapes.single_objective, inspect.isfunction
     )

--- a/swarmlib/util/functions.py
+++ b/swarmlib/util/functions.py
@@ -18,7 +18,7 @@ def michalewicz(x):
     def func(x):
         return np.sin(x) * np.power(np.sin((0 + 1) * np.power(x, 2) / np.pi), 2 * m)
 
-    result = reduce(lambda acc, x: acc + func(x), x, 0.)
+    result = reduce(lambda acc, x: acc + func(x), x, 0.0)
     return -result
 
 
@@ -44,6 +44,7 @@ FUNCTIONS = {
     for (name, func) in inspect.getmembers(
         landscapes.single_objective, inspect.isfunction
     )
+    if name not in ['colville', 'wolfe'] # Don't include 3D and 4D functions
 }
 # Replace / add functions that are defined in this file
 FUNCTIONS.update({'michalewicz': michalewicz, 'ackley': ackley})


### PR DESCRIPTION
# Summary
<!-- Please give a brief summary about what changes with this pull request -->
This PR integrates benchmark functions from the [`landscapes`](https://github.com/nathanrooy/landscapes) package, so they can be used from the swarmlib CLI.

# Changes
<!-- List detailed changes here as bullets -->
* Add `landscapes` functions to `FUNCTIONS` dict in `swarmlib/util/functions.py` while retaining functions that are defined in this file
* Make new function choices available in swarmlib CLI by modification of the `main.py` of: abc, cuckoosearch, fireflyalgorithm, gwo and pso.
* Wrap `landscapes` functions to support inputs > 1d
* Minor: Organise imports in `swarmlib/util/functions.py` and update `requirements.txt` 

# Related Issues
<!-- Mention the issue this PR relates to. E.g.: Fixes #1 -->
Fixes #15 .